### PR TITLE
Add EarthscapeHub badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# landscape_metrics_course
+# landscape metrics course
 
-This repo contains code for a Tulane Spring 2021 graduate course, led by Nicole Gasparini.
+This repo contains code for a Tulane Spring 2023 graduate course, led by Nicole Gasparini.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # landscape metrics course
 
+[![Run on EarthscapeHub][badge]][jhub-link]
+
 This repo contains code for a Tulane Spring 2023 graduate course, led by Nicole Gasparini.
+
+<!-- Links -->
+
+[badge]: https://img.shields.io/badge/Run%20on-EarthscapeHub-orange
+[jhub-link]: https://lab.openearthscape.org/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Flandlab%2Flandscape_metrics_course&urlpath=lab%2Ftree%2Flandscape_metrics_course%2F%3Fautodecode&branch=main


### PR DESCRIPTION
This PR adds a button with an [nbgitpuller](https://hub.jupyter.org/nbgitpuller/index.html) link to the README. Clicking the button takes a user to [EarthscapeHub](https://csdms.colorado.edu/wiki/JupyterHub), where, if they have a login, they can run the notebooks from the repo.